### PR TITLE
[Autofix][critical] Alert #41: Year field changed using an arithmetic operation without checking for leap year

### DIFF
--- a/XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp
+++ b/XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp
@@ -616,7 +616,13 @@ bool CVerification_XAuthKey::Verification_XAuthKey_KeyInit(VERIFICATION_XAUTHKEY
 	{
 		XENGINE_LIBTIME st_LibTime = {};
 		BaseLib_Time_GetSysTime(&st_LibTime);
-		st_LibTime.wYear += 1;
+		int nTargetYear = st_LibTime.wYear + 1;
+		bool bIsLeapYear = (0 == (nTargetYear % 4)) && ((0 != (nTargetYear % 100)) || (0 == (nTargetYear % 400)));
+		if ((2 == st_LibTime.wMonth) && (29 == st_LibTime.wDay) && !bIsLeapYear)
+		{
+			st_LibTime.wDay = 28;
+		}
+		st_LibTime.wYear = nTargetYear;
 		BaseLib_Time_TimeToStr(pSt_XAuthInfo->st_AuthSerial.st_DataLimit.tszDataTime, NULL, true, &st_LibTime);
 		Verification_XAuthKey_KeySerial(pSt_XAuthInfo->st_AuthSerial.st_DataLimit.tszDataSerial, 7, 0);
 	}


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复

      **Alert ID:** #41
      **Security Severity:** critical
      **Rule:** Year field changed using an arithmetic operation without checking for leap year

      此 PR 由 Copilot Autofix 自动生成，请审核后再 merge。

      - [ ] 确认修复逻辑正确
      - [ ] 确认没有引入新问题
      - [ ] CI 测试通过