### PR TITLE
[Autofix][critical] Alert #32: Missing header guard

### DIFF
--- a/XEngine_Module/XEngine_Verification/pch.h
+++ b/XEngine_Module/XEngine_Verification/pch.h
@@ -15,7 +15,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #endif
-#endif //PCH_H
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -89,3 +88,4 @@ extern XLONG Verification_dwErrorCode;
 #endif
 #endif
 #endif
+#endif //PCH_H


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复

      **Alert ID:** #32
      **Security Severity:** critical
      **Rule:** Missing header guard

      此 PR 由 Copilot Autofix 自动生成，请审核后再 merge。

      - [ ] 确认修复逻辑正确
      - [ ] 确认没有引入新问题
      - [ ] CI 测试通过