### PR TITLE
[Autofix][critical] Alert #31: Missing header guard

### DIFF
--- a/XEngine_Module/XEngine_Token/pch.h
+++ b/XEngine_Module/XEngine_Token/pch.h
@@ -11,7 +11,6 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include "framework.h"
 #endif
-#endif //PCH_H
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,3 +45,4 @@ extern XLONG Session_dwErrorCode;
 #ifdef _MSC_BUILD
 #pragma comment(lib,"XEngine_BaseLib/XEngine_BaseLib")
 #endif
+#endif // PCH_H


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复

      **Alert ID:** #31
      **Security Severity:** critical
      **Rule:** Missing header guard

      此 PR 由 Copilot Autofix 自动生成，请审核后再 merge。

      - [ ] 确认修复逻辑正确
      - [ ] 确认没有引入新问题
      - [ ] CI 测试通过