### PR TITLE
[Autofix][critical] Alert #30: Missing header guard

### DIFF
--- a/XEngine_Module/XEngine_PluginExtension/pch.h
+++ b/XEngine_Module/XEngine_PluginExtension/pch.h
@@ -15,7 +15,6 @@
 #else
 #include <dlfcn.h>
 #endif
-#endif //PCH_H
 #ifdef _XENGINE_BUILD_SWITCH_LUA
 #include <lua.hpp>
 #endif
@@ -57,3 +56,4 @@ extern XLONG PluginExtension_dwErrorCode;
 #else
 #define XFreeModule dlclose
 #endif
+#endif //PCH_H


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复

      **Alert ID:** #30
      **Security Severity:** critical
      **Rule:** Missing header guard

      此 PR 由 Copilot Autofix 自动生成，请审核后再 merge。

      - [ ] 确认修复逻辑正确
      - [ ] 确认没有引入新问题
      - [ ] CI 测试通过