### PR TITLE
[Autofix][high] Alert #46: File created without restricting permissions

### DIFF
--- a/XEngine_Module/XEngine_AIApi/AIApi_Help/AIApi_Help.cpp
+++ b/XEngine_Module/XEngine_AIApi/AIApi_Help/AIApi_Help.cpp
@@ -1,5 +1,8 @@
 ﻿#include "pch.h"
 #include "AIApi_Help.h"
+#include <fcntl.h>
+#include <io.h>
+#include <sys/stat.h>
 /********************************************************************
 //    Created:     2025/07/10  15:46:31
 //    File Name:   D:\XEngine_OPenSource\XEngine_Module\XEngine_AIApi\AIApi_Help\AIApi_Help.cpp
@@ -205,9 +208,17 @@ bool CAIApi_Help::AIApi_Help_Base64DecodecFile(LPCXSTR lpszMSGBuffer, int nMSGLe
 		AIApi_dwErrorCode = Cryption_GetLastError();
 		return false;
 	}
-	FILE* pSt_File = _xtfopen(lpszFileName, _X("wb"));
+	int nFD = _open(lpszFileName, _O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY, _S_IREAD | _S_IWRITE);
+	if (-1 == nFD)
+	{
+		AIApi_IsErrorOccur = true;
+		AIApi_dwErrorCode = ERROR_XENGINE_MODULE_AIAPI_HELP_OPENFILE;
+		return false;
+	}
+	FILE* pSt_File = _fdopen(nFD, "wb");
 	if (NULL == pSt_File)
 	{
+		_close(nFD);
 		AIApi_IsErrorOccur = true;
 		AIApi_dwErrorCode = ERROR_XENGINE_MODULE_AIAPI_HELP_OPENFILE;
 		return false;


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#46](https://github.com/libxengine/XEngine_OPenSource/security/code-scanning/46) |
| **安全级别** | high |
| **规则名称** | File created without restricting permissions |
| **问题文件** | `XEngine_Module/XEngine_AIApi/AIApi_Help/AIApi_Help.cpp` 第 208 行 |
| **CWE 分类** | external/cwe/cwe-732 |
| **规则标签** | external/cwe/cwe-732, security |

---

### 🔍 问题说明

# File created without restricting permissions
When you create a file, take care to give it the most restrictive permissions possible. A typical mistake is to create the file with world-writable permissions. This can allow an attacker to write to the file, which can give them unexpected control over the program.


## Recommendation
Files should usually be created with write permissions only for the current user. If broader permissions are needed, including the users' group should be sufficient. It is very rare that a file needs to be world-writable, and care should be taken not to make assumptions about the contents of any such file.

On Unix systems, it is possible for the user who runs the program to restrict file creation permissions using `umask`. However, a program should not assume t

---

### 🤖 AI 修复思路

通用修复方式：避免用仅靠默认权限创建文件的 API（如 `fopen("wb")`），改为先用可显式指定权限的低层接口创建文件（如 `open`/`_open`），权限设置为仅属主可读写（Unix 上 `0600`），再转换为 `FILE*` 进行 `fwrite`，从而不改变原有写文件逻辑。

本片段的最佳改法（不改变功能）：
- 修改 `XEngine_Module/XEngine_AIApi/AIApi_Help/AIApi_Help.cpp` 中第 208 行附近文件创建逻辑。
- 将 `_xtfopen(lpszFileName, _X("wb"))` 替换为：
  - `_open` + `_O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY` + `_S_IREAD | _S_IWRITE`（Windows 下仅当前用户读写语义）
  - 再用 `_fdopen(fd, "wb")` 转为 `FILE*`
- 增加失败分支：`_fdopen` 失败时关闭 fd，避免句柄泄漏。
- 需要新增头文件：`<fcntl.h>`, `<io.h>`, `<sys/stat.h>`（均为常见标准/平台头）。

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。