### PR TITLE
[Autofix][high] Alert #47: File created without restricting permissions

### DIFF
--- a/XEngine_Module/XEngine_AIApi/pch.h
+++ b/XEngine_Module/XEngine_AIApi/pch.h
@@ -10,13 +10,15 @@
 // 添加要在此处预编译的标头
 #define _CRT_SECURE_NO_WARNINGS
 #include "framework.h"
+#include <io.h>
 #endif
 #endif //PCH_H
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <io.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <json/json.h>
 #include <thread>
 #include <memory>

--- a/XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp
+++ b/XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp
@@ -1,5 +1,8 @@
 ﻿#include "pch.h"
 #include "Verification_XAuthKey.h"
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 /********************************************************************
 //    Created:     2025/09/30  16:47:21
 //    File Name:   D:\XEngine_OPenSource\XEngine_Module\XEngine_Verification\Verification_XAuth\Verification_XAuthKey.cpp
@@ -151,10 +154,18 @@ bool CVerification_XAuthKey::Verification_XAuthKey_FileWrite(VERIFICATION_XAUTHK
 	{
 		return false;
 	}
-	//打开文件
-	FILE* pSt_File = _xtfopen(lpszKeyFile, _X("wb"));
+	//打开文件(限制为仅当前用户可读写)
+	int nFile = open(lpszKeyFile, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+	if (nFile < 0)
+	{
+		Verification_IsErrorOccur = true;
+		Verification_dwErrorCode = ERROR_XENGINE_MODULE_VERIFICATION_XAUTH_OPENFILE;
+		return false;
+	}
+	FILE* pSt_File = fdopen(nFile, "wb");
 	if (NULL == pSt_File)
 	{
+		close(nFile);
 		Verification_IsErrorOccur = true;
 		Verification_dwErrorCode = ERROR_XENGINE_MODULE_VERIFICATION_XAUTH_OPENFILE;
 		return false;

--- a/XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp
+++ b/XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp
@@ -1,8 +1,5 @@
 ﻿#include "pch.h"
 #include "Verification_XAuthKey.h"
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
 /********************************************************************
 //    Created:     2025/09/30  16:47:21
 //    File Name:   D:\XEngine_OPenSource\XEngine_Module\XEngine_Verification\Verification_XAuth\Verification_XAuthKey.cpp
@@ -155,17 +152,16 @@ bool CVerification_XAuthKey::Verification_XAuthKey_FileWrite(VERIFICATION_XAUTHK
 		return false;
 	}
 	//打开文件(限制为仅当前用户可读写)
-	int nFile = open(lpszKeyFile, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
-	if (nFile < 0)
-	{
-		Verification_IsErrorOccur = true;
-		Verification_dwErrorCode = ERROR_XENGINE_MODULE_VERIFICATION_XAUTH_OPENFILE;
-		return false;
-	}
+#ifdef _MSC_BUILD
+	int nFile = _xtopen(lpszKeyFile, _O_WRONLY | _O_CREAT | _O_TRUNC | _O_BINARY, _S_IREAD | _S_IWRITE);
+	FILE* pSt_File = _fdopen(nFile, "wb");
+#else
+	int nFile = _xtopen(lpszKeyFile, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
 	FILE* pSt_File = fdopen(nFile, "wb");
+#endif
 	if (NULL == pSt_File)
 	{
-		close(nFile);
+		_close(nFile);
 		Verification_IsErrorOccur = true;
 		Verification_dwErrorCode = ERROR_XENGINE_MODULE_VERIFICATION_XAUTH_OPENFILE;
 		return false;

--- a/XEngine_Module/XEngine_Verification/pch.h
+++ b/XEngine_Module/XEngine_Verification/pch.h
@@ -8,12 +8,11 @@
 #define PCH_H
 #ifdef _MSC_BUILD
 #define _CRT_SECURE_NO_WARNINGS
-#include <io.h>
 // 添加要在此处预编译的标头
 #include "framework.h"
+#include <io.h>
 #else
 #include <unistd.h>
-#include <fcntl.h>
 #endif
 #endif //PCH_H
 #include <stdio.h>
@@ -21,6 +20,8 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <json/json.h>
 #include <shared_mutex>
 #include <thread>


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#47](https://github.com/libxengine/XEngine_OPenSource/security/code-scanning/47) |
| **安全级别** | high |
| **规则名称** | File created without restricting permissions |
| **问题文件** | `XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp` 第 155 行 |
| **CWE 分类** | external/cwe/cwe-732 |
| **规则标签** | external/cwe/cwe-732, security |

---

### 🔍 问题说明

# File created without restricting permissions
When you create a file, take care to give it the most restrictive permissions possible. A typical mistake is to create the file with world-writable permissions. This can allow an attacker to write to the file, which can give them unexpected control over the program.


## Recommendation
Files should usually be created with write permissions only for the current user. If broader permissions are needed, including the users' group should be sufficient. It is very rare that a file needs to be world-writable, and care should be taken not to make assumptions about the contents of any such file.

On Unix systems, it is possible for the user who runs the program to restrict file creation permissions using `umask`. However, a program should not assume t

---

### 🤖 AI 修复思路

Use a secure create-open path that explicitly sets restrictive permissions when creating the key file, instead of plain `_xtfopen(...,"wb")`.

Best fix in this function:
- Replace `_xtfopen(lpszKeyFile, _X("wb"))` with:
  1. low-level `open(..., O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR)` (owner read/write only, `0600`);
  2. convert descriptor to `FILE*` via `fdopen(..., "wb")`.
- Keep existing write/encryption logic unchanged.
- Add error handling for both `open` and `fdopen` failure (and close fd on `fdopen` failure).
- Add required headers for `open`, flags, and mode macros in this cpp file.

This preserves behavior (overwrite/create and binary write) while enforcing restrictive permissions at creation time.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。