### PR TITLE
[Autofix][warning] Alert #41: Year field changed using an arithmetic operation without checking for leap year

### DIFF
--- a/XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp
+++ b/XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp
@@ -624,6 +624,11 @@ bool CVerification_XAuthKey::Verification_XAuthKey_KeyInit(VERIFICATION_XAUTHKEY
 		XENGINE_LIBTIME st_LibTime = {};
 		BaseLib_Time_GetSysTime(&st_LibTime);
 		st_LibTime.wYear += 1;
+		bool bIsLeapYear = (0 == (st_LibTime.wYear % 4)) && ((0 != (st_LibTime.wYear % 100)) || (0 == (st_LibTime.wYear % 400)));
+		if ((2 == st_LibTime.wMonth) && (29 == st_LibTime.wDay) && !bIsLeapYear)
+		{
+			st_LibTime.wDay = 28;
+		}
 		BaseLib_Time_TimeToStr(pSt_XAuthInfo->st_AuthSerial.st_DataLimit.tszDataTime, NULL, true, &st_LibTime);
 		Verification_XAuthKey_KeySerial(pSt_XAuthInfo->st_AuthSerial.st_DataLimit.tszDataSerial, 7, 0);
 	}


### PR DESCRIPTION
## 🤖 Copilot Autofix 自动修复报告

---

### 📋 基本信息

| 字段 | 内容 |
|------|------|
| **Alert ID** | [#41](https://github.com/libxengine/XEngine_OPenSource/security/code-scanning/41) |
| **安全级别** | warning |
| **规则名称** | Year field changed using an arithmetic operation without checking for leap year |
| **问题文件** | `XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp` 第 626 行 |
| **CWE 分类** |  |
| **规则标签** | correctness, leap-year |

---

### 🔍 问题说明

# Year field changed using an arithmetic operation without checking for leap year
The leap year rule for the Gregorian calendar, which has become the internationally accepted civil calendar, is: every year that is exactly divisible by four is a leap year, except for years that are exactly divisible by 100, but these centurial years are leap years if they are exactly divisible by 400.

A leap year bug occurs when software (in any language) is written without consideration of leap year logic, or with flawed logic to calculate leap years; which typically results in incorrect results.

The impact of these bugs may range from almost unnoticeable bugs such as an incorrect date, to severe bugs that affect reliability, availability or even the security of the affected system.

When performing arit

---

### 🤖 AI 修复思路

To fix this safely, keep the existing behavior (add one year) but add a leap-year validity adjustment immediately after incrementing the year.

Best fix in this snippet:
- In `XEngine_Module/XEngine_Verification/Verification_XAuth/Verification_XAuthKey.cpp`, in the block where `st_LibTime` is initialized and `wYear` is incremented, add:
  1. leap-year calculation for the **new** year,
  2. conditional correction from Feb 29 to Feb 28 when the new year is not leap.
- No new includes or external dependencies are needed.

This preserves all existing functionality while ensuring the generated date is always valid.

---

### ✅ Review 检查清单

- [ ] 理解了漏洞的成因和影响范围
- [ ] 确认 AI 修复逻辑正确，没有遗漏边界情况
- [ ] 确认修复没有改变原有业务逻辑
- [ ] 确认没有引入新的安全问题
- [ ] CI / 单元测试全部通过
- [ ] 如有必要，已补充对应的测试用例

---

> 此 PR 由 GitHub Copilot Autofix 自动生成，请仔细审核后再 merge。